### PR TITLE
Add --force-build flag

### DIFF
--- a/cmd/mmbuild/main.go
+++ b/cmd/mmbuild/main.go
@@ -13,7 +13,7 @@ var rootCmd = &cobra.Command{}
 
 var buildCmd = &cobra.Command{
 	Use: "build",
-	//SilenceUsage:  true,
+	// SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runBuild(bOpts)
@@ -21,8 +21,7 @@ var buildCmd = &cobra.Command{
 }
 
 var replayCmd = &cobra.Command{
-	Use: "replay",
-	// SilenceUsage:  true,
+	Use:           "replay",
 	SilenceErrors: true,
 	Args:          cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -31,6 +30,7 @@ var replayCmd = &cobra.Command{
 }
 
 type buildOpts = struct {
+	forceBuild bool
 	configFile string
 	workDir    string
 }
@@ -39,17 +39,24 @@ type replayOpts = struct {
 	workDir string
 }
 
-var bOpts = &buildOpts{}
-var rOpts = &replayOpts{}
+var (
+	bOpts = &buildOpts{}
+	rOpts = &replayOpts{}
+)
 
 func init() {
+	// Options for mmbuild build
 	buildCmd.PersistentFlags().StringVar(
 		&bOpts.configFile, "conf", "", "configuration file for the build",
 	)
 	buildCmd.PersistentFlags().StringVarP(
 		&bOpts.workDir, "workdir", "w", ".", "working directory where the build will run",
 	)
+	replayCmd.PersistentFlags().BoolVarP(
+		&bOpts.forceBuild, "force", "f", false, "execute the builder even if artifacts are found",
+	)
 
+	// Options for mmbuild replay
 	replayCmd.PersistentFlags().StringVarP(
 		&rOpts.workDir, "workdir", "w", ".", "working directory where the replay will run",
 	)
@@ -70,6 +77,7 @@ func runBuild(opts *buildOpts) (err error) {
 	}
 
 	b.Options().Workdir = opts.workDir
+	b.Options().ForceBuild = opts.forceBuild
 
 	run := b.Run()
 	return errors.Wrap(run.Execute(), "executing build run")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mattermost/builder
 go 1.17
 
 require (
-	github.com/mattermost/cicd-sdk v0.0.0-20211223033541-883654db2b57
+	github.com/mattermost/cicd-sdk v0.0.0-20211223231557-c9a662396e1e
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXq
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
-github.com/mattermost/cicd-sdk v0.0.0-20211223033541-883654db2b57 h1:0TNnvfZswNkzG1jNsuqOBh1mvwe1PqPJGWXPAj9bTZg=
-github.com/mattermost/cicd-sdk v0.0.0-20211223033541-883654db2b57/go.mod h1:ATz3AC9JNpDJ7G8pzKPuPwTsJM3XSl6U+MjFMaVc4As=
+github.com/mattermost/cicd-sdk v0.0.0-20211223231557-c9a662396e1e h1:GpET1SYmh2lRjFxcl14FnvB7H3BJB3AS6ZuZLEpKB0Q=
+github.com/mattermost/cicd-sdk v0.0.0-20211223231557-c9a662396e1e/go.mod h1:ATz3AC9JNpDJ7G8pzKPuPwTsJM3XSl6U+MjFMaVc4As=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
#### Summary
This commit adds a new flag to the builder CLI that controls if the builder is executed when
artifacts are found.

Depends on https://github.com/mattermost/cicd-sdk/pull/18

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Ticket Link

https://mattermost.atlassian.net/jira/software/projects/DOPS/boards/66?selectedIssue=DOPS-706