### PR TITLE
Make build conf file primary source for plugins 

### DIFF
--- a/cmd/mmbuild/main.go
+++ b/cmd/mmbuild/main.go
@@ -53,16 +53,19 @@ func init() {
 	buildCmd.PersistentFlags().StringVarP(
 		&bOpts.workDir, "workdir", "w", ".", "working directory where the build will run",
 	)
-	replayCmd.PersistentFlags().BoolVarP(
+	buildCmd.PersistentFlags().BoolVarP(
 		&bOpts.forceBuild, "force", "f", false, "execute the builder even if artifacts are found",
 	)
-	replayCmd.PersistentFlags().BoolVar(
+	buildCmd.PersistentFlags().BoolVar(
 		&bOpts.SBOM, "sbom", false, "write an sbom to the workind directory after building",
 	)
 
 	// Options for mmbuild replay
 	replayCmd.PersistentFlags().StringVarP(
 		&rOpts.workDir, "workdir", "w", ".", "working directory where the replay will run",
+	)
+	replayCmd.PersistentFlags().BoolVarP(
+		&bOpts.forceBuild, "force", "f", false, "execute the builder even if artifacts are found",
 	)
 
 	rootCmd.AddCommand(buildCmd)

--- a/examples/server/Makefile
+++ b/examples/server/Makefile
@@ -110,21 +110,11 @@ TE_PACKAGES=$(shell $(GO) list ./... | grep -v ./data)
 
 TEMPLATES_DIR=templates
 
-# Plugins Packages
-PLUGIN_PACKAGES ?= mattermost-plugin-antivirus-v0.1.2
-PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.2.2
-PLUGIN_PACKAGES += mattermost-plugin-aws-SNS-v1.2.0
-PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.3.0
-PLUGIN_PACKAGES += mattermost-plugin-github-v2.0.1
-PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.3.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.22.1
-PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.1.0
-PLUGIN_PACKAGES += mattermost-plugin-jira-v2.4.0
-PLUGIN_PACKAGES += mattermost-plugin-nps-v1.1.0
-PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
-PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.5.0
-PLUGIN_PACKAGES += focalboard-v0.10.0
+# Plugins Packages. These are defined in the build configuration
+# file matterbuild.yaml
+ifndef PLUGIN_PACKAGES
+	PLUGIN_PACKAGES=$(shell grep -A1 "var: MM_PLUGIN" matterbuild.yaml  | grep value: | awk '{print $2}' | tr  "\n", " ")
+endif
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)

--- a/examples/server/matterbuild.yaml
+++ b/examples/server/matterbuild.yaml
@@ -7,7 +7,34 @@ runner:
 env:     
   - var: PLUGIN_STORE_URL
     value: https://plugins-store.test.mattermost.com/release
-  - var: MMBUILD_STAGING_PATH
+  - var: MM_PLUGIN_ANTIVIRUS
+    value: mattermost-plugin-antivirus-v0.1.2
+  - var: MM_PLUGIN_AUTLOINK
+    value: mattermost-plugin-autolink-v1.2.2
+  - var: MM_PLUGIN_AWS_SNS
+    value: mattermost-plugin-aws-SNS-v1.2.0
+  - var: MM_PLUGIN_CHANNEL_EXPORT
+    value: mattermost-plugin-channel-export-v1.0.0
+  - var: MM_PLUGIN_CUSTOM_ATTRS
+    value: mattermost-plugin-custom-attributes-v1.3.0
+  - var: MM_PLUGIN_GITHUB
+    value: mattermost-plugin-github-v2.0.1
+  - var: MM_PLUGIN_GITLAB
+    value: mattermost-plugin-gitlab-v1.3.0
+  - var: MM_PLUGIN_PLAYBOOKS
+    value: mattermost-plugin-playbooks-v1.22.1
+  - var: MM_PLUGIN_JENKINS
+    value: mattermost-plugin-jenkins-v1.1.0
+  - var: MM_PLUGIN_JIRA
+    value: mattermost-plugin-jira-v2.4.0
+  - var: MM_PLUGIN_NPS
+    value: mattermost-plugin-nps-v1.1.0
+  - var: MM_PLUGIN_WELCOMEBOT
+    value: mattermost-plugin-welcomebot-v1.2.0
+  - var: MM_PLUGIN_ZOOM
+    value: mattermost-plugin-zoom-v1.5.0
+  - var: MM_PLUGIN_FOCALBOARD
+    value: focalboard-v0.11.0
 #replacements:
 #  - paths: [mattermost-server/app/server.go]
 #    tag: "$SENTRY_DSN"
@@ -39,46 +66,46 @@ materials:
   #  digest:
   #    sha1: e97447134cd650ee9f9da5d705a06d3c548d3d6c
   - uri: s3://mattermost-development-test/build-test/${MMBUILD_STAGING_PATH}/mattermost-webapp.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-antivirus-v0.1.2-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-autolink-v1.2.2-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-aws-SNS-v1.2.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-channel-export-v1.0.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-custom-attributes-v1.3.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-github-v2.0.1-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-gitlab-v1.3.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-playbooks-v1.22.1-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-jenkins-v1.1.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-jira-v2.4.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-nps-v1.1.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-welcomebot-v1.2.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-zoom-v1.5.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/focalboard-v0.10.0-linux-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-antivirus-v0.1.2-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-autolink-v1.2.2-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-aws-SNS-v1.2.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-channel-export-v1.0.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-custom-attributes-v1.3.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-github-v2.0.1-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-gitlab-v1.3.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-playbooks-v1.22.1-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-jenkins-v1.1.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-jira-v2.4.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-nps-v1.1.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-welcomebot-v1.2.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-zoom-v1.5.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/focalboard-v0.10.0-osx-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-antivirus-v0.1.2-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-autolink-v1.2.2-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-aws-SNS-v1.2.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-channel-export-v1.0.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-custom-attributes-v1.3.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-github-v2.0.1-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-gitlab-v1.3.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-playbooks-v1.22.1-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-jenkins-v1.1.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-jira-v2.4.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-nps-v1.1.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-welcomebot-v1.2.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/mattermost-plugin-zoom-v1.5.0-windows-amd64.tar.gz
-  - uri: ${PLUGIN_STORE_URL}/focalboard-v0.10.0-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ANTIVIRUS}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AUTLOINK}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AWS_SNS}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_CHANNEL_EXPORT}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_CUSTOM_ATTRS}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_GITHUB}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_GITLAB}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_PLAYBOOKS}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_JENKINS}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_JIRA}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_NPS}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_WELCOMEBOT}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ZOOM}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_FOCALBOARD}-linux-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ANTIVIRUS}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AUTLOINK}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AWS_SNS}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_CHANNEL_EXPORT}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_CUSTOM_ATTRS}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_GITHUB}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_GITLAB}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_PLAYBOOKS}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_JENKINS}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_JIRA}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_NPS}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_WELCOMEBOT}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ZOOM}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_FOCALBOARD}-osx-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ANTIVIRUS}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AUTLOINK}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AWS_SNS}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_CHANNEL_EXPORT}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_CUSTOM_ATTRS}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_GITHUB}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_GITLAB}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_PLAYBOOKS}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_JENKINS}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_JIRA}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_NPS}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_WELCOMEBOT}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ZOOM}-windows-amd64.tar.gz
+  - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_FOCALBOARD}-windows-amd64.tar.gz
   

--- a/examples/server/matterbuild.yaml
+++ b/examples/server/matterbuild.yaml
@@ -65,6 +65,8 @@ materials:
   #- uri: "s3://mattermost-development-test/build-test/"
   #  digest:
   #    sha1: e97447134cd650ee9f9da5d705a06d3c548d3d6c
+  ## MMBUILD_STAGING_PATH here will come from the previous run of the webapp build
+  ## For testing, try:  export MMBUILD_STAGING_PATH=133e9fe20423cc76a3ee9da69b48fe1a4bb4d3d8f1180f48b1c6dc6e164d632c
   - uri: s3://mattermost-development-test/build-test/${MMBUILD_STAGING_PATH}/mattermost-webapp.tar.gz
   - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_ANTIVIRUS}-linux-amd64.tar.gz
   - uri: ${PLUGIN_STORE_URL}/${MM_PLUGIN_AUTLOINK}-linux-amd64.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mattermost/builder
 go 1.17
 
 require (
-	github.com/mattermost/cicd-sdk v0.0.0-20211229090438-461a7ac97bbf
+	github.com/mattermost/cicd-sdk v0.0.0-20211231145739-f7c6615b5fba
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -598,8 +598,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
-github.com/mattermost/cicd-sdk v0.0.0-20211229090438-461a7ac97bbf h1:PtWc24KRCfY4rrkXrGrMxrN0JhW5QbV1LA6RhpnMeFw=
-github.com/mattermost/cicd-sdk v0.0.0-20211229090438-461a7ac97bbf/go.mod h1:82cO65dhjS5LpglePcOoKXOW6Mhn4dCTnPW8q0FhHfk=
+github.com/mattermost/cicd-sdk v0.0.0-20211231145739-f7c6615b5fba h1:Ac4DYyTD4xlk1gZblVPmy6fHkpxuz5mcsheI1Vf6aRg=
+github.com/mattermost/cicd-sdk v0.0.0-20211231145739-f7c6615b5fba/go.mod h1:82cO65dhjS5LpglePcOoKXOW6Mhn4dCTnPW8q0FhHfk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
#### Summary
This PR compiles a few changes but most importantly has a change for the main server Makefile to extract the plugin list from the `matterbuild.yaml` file. This is only in the vuilder/examples directory, so nothing in the real Makefile is affected for now.
